### PR TITLE
"chore: Mejorar .gitignore para proyecto Mulesoft"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,11 @@
-# Compiled class file
+# Archivos compilados
 *.class
 
-# Log file
+# Logs
 *.log
+logs/
 
-# BlueJ files
-*.ctxt
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
+# Archivos de empaquetado
 *.jar
 *.war
 *.nar
@@ -19,6 +14,11 @@
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# Errores de la JVM
 hs_err_pid*
 replay_pid*
+
+# Mulesoft
+target/
+*/.mule/
+.settings/


### PR DESCRIPTION
Este commit mejora el archivo .gitignore para excluir archivos específicos de Mulesoft y otros archivos generados o temporales que no deberían ser incluidos en el repositorio.

Se han añadido las siguientes entradas:

* `target/`: Excluye la carpeta target generada por Maven.
* `*/.mule/`: Excluye las carpetas .mule generadas por Anypoint Studio.
* `.settings/`: Excluye la configuración específica del workspace de Anypoint Studio.
* `logs/`: Excluye los archivos de registro generados por la aplicación.

Se han eliminado las siguientes entradas (innecesarias para un proyecto Mulesoft):

* `.ctxt`
* `.mtj.tmp/`

Esto ayuda a mantener el repositorio limpio y a evitar conflictos al compartir el proyecto.

## Resumen por Sourcery

Tareas:
- Mejorar el archivo .gitignore para excluir archivos específicos relacionados con Mulesoft y otros archivos generados o temporales.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Improve the .gitignore file to exclude specific Mulesoft-related files and other generated or temporary files.

</details>